### PR TITLE
Preserve-data-in-browser

### DIFF
--- a/script.js
+++ b/script.js
@@ -94,6 +94,7 @@ function populateStorage() {
   };
   localStorage.setItem('userInput', JSON.stringify(userInput));
 }
+
 function setForm() {
   const storedInput = JSON.parse(localStorage.getItem('userInput'));
   const currentUserName = storedInput.name;
@@ -103,6 +104,7 @@ function setForm() {
   form.elements.email.value = currentUserEmail;
   form.elements.message.value = currentMessage;
 }
+
 if (!localStorage.getItem('userInput')) {
   populateStorage();
 } else {

--- a/script.js
+++ b/script.js
@@ -82,3 +82,32 @@ form.addEventListener('submit', (event) => {
     event.preventDefault();
   }
 });
+
+const userName = form.elements.name;
+const userEmail = form.elements.email;
+const userMessage = form.elements.message;
+function populateStorage() {
+  const userInput = {
+    name: form.elements.name.value,
+    email: form.elements.email.value,
+    message: form.elements.message.value,
+  };
+  localStorage.setItem('userInput', JSON.stringify(userInput));
+}
+function setForm() {
+  const storedInput = JSON.parse(localStorage.getItem('userInput'));
+  const currentUserName = storedInput.name;
+  const currentUserEmail = storedInput.email;
+  const currentMessage = storedInput.message;
+  form.elements.name.value = currentUserName;
+  form.elements.email.value = currentUserEmail;
+  form.elements.message.value = currentMessage;
+}
+if (!localStorage.getItem('userInput')) {
+  populateStorage();
+} else {
+  setForm();
+}
+userName.onchange = populateStorage;
+userEmail.onchange = populateStorage;
+userMessage.onchange = populateStorage;

--- a/script.js
+++ b/script.js
@@ -82,7 +82,7 @@ form.addEventListener('submit', (event) => {
     event.preventDefault();
   }
 });
-
+// Preserve Data in Local Storage //
 const userName = form.elements.name;
 const userEmail = form.elements.email;
 const userMessage = form.elements.message;


### PR DESCRIPTION
In this pull request I have made some changes :
-Save data to local storage
-When the user loads the page, if there is any data in the local storage the input fields are pre-filled with this data.